### PR TITLE
Add `Disallow:` to robots.txt

### DIFF
--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,3 +1,4 @@
-# robotstxt.org/
+# www.robotstxt.org/
 
 User-agent: *
+Disallow:


### PR DESCRIPTION
See https://github.com/yeoman/generator-mobile/pull/58:
- According to the [robots.txt standard](http://www.robotstxt.org/orig.html) at least one disallow rule must be added: 
  
  > The record starts with one or more User-agent lines, followed by one or more Disallow lines, as detailed below.
- The URL `robotstxt.org` is broken.
  ![screenshot 2014-11-02 09 07 39](https://cloud.githubusercontent.com/assets/6025224/4874651/599b3616-6267-11e4-9fc1-8b4d965fecda.png)

See the [discussion about this in h5bp too](https://github.com/h5bp/html5-boilerplate/issues/1487)
